### PR TITLE
Fix a bug that can't trim white space on OS X

### DIFF
--- a/helm-dired-recent-dirs.el
+++ b/helm-dired-recent-dirs.el
@@ -54,7 +54,7 @@ zstyle \":chpwd:*\" recent-dirs-max %d"
   '((name . "Dired History:")
     (init .  (lambda ()
                (call-process-shell-command
-                (format "%s && cdr -l | sed 's/[0-9]*\\s*//'"
+                (format "%s && cdr -l | sed 's/[0-9]*[[:space:]]*//'"
                         (helm-dired-recent-dirs-init-script))
                 nil
                 (helm-candidate-buffer 'global))))


### PR DESCRIPTION
Replace \s with [:space:] so OS X sed(BSD sed) can't use PCRE style like '\s'.
